### PR TITLE
Add support for epel9

### DIFF
--- a/cargo2rpm/cargo2rpm.spec
+++ b/cargo2rpm/cargo2rpm.spec
@@ -1,4 +1,7 @@
 %bcond_without check
+%if %{defined el9}
+%global python3_pkgversion 3.11
+%endif
 
 %global commit e1ff24ed84dc6801458df5609921f33229d03895
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
@@ -14,7 +17,10 @@ Source:         %{url}/archive/%{commit}/cargo2rpm-%{shortcommit}.tar.gz
 
 BuildArch:      noarch
 
-BuildRequires:  python3-devel
+BuildRequires:  python%{python3_pkgversion}-devel
+%if %{with check}
+BuildRequires:  %{py3_dist pytest}
+%endif
 
 Requires:       cargo
 
@@ -25,7 +31,7 @@ Low-level translation layer between cargo and RPM.
 %autosetup -n cargo2rpm-%{shortcommit} -p1
 
 %generate_buildrequires
-%pyproject_buildrequires -t
+%pyproject_buildrequires
 
 %build
 %pyproject_wheel
@@ -35,7 +41,7 @@ Low-level translation layer between cargo and RPM.
 
 %check
 %if %{with check}
-%tox
+%pytest
 %endif
 
 %files

--- a/rust2rpm/rust2rpm.spec
+++ b/rust2rpm/rust2rpm.spec
@@ -1,5 +1,8 @@
 # tests have not been fixed for required spec file generation changes
 %bcond_with check
+%if %{defined el9}
+%global python3_pkgversion 3.11
+%endif
 
 %global commit 3443c98887f019eab11903f1fc76f086cbf0814c
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
@@ -22,6 +25,7 @@ BuildRequires:  python3-devel
 
 %if %{with check}
 BuildRequires:  cargo
+BuildRequires:  %{py3_dist pytest}
 %endif
 
 Requires:       cargo
@@ -32,10 +36,15 @@ Requires:       cargo-rpm-macros
 Obsoletes:      cargo-inspector < 24
 
 # obsolete + provide removed Python subpackages
-Provides:       python3-rust2rpm = %{version}-%{release}
 Obsoletes:      python3-rust2rpm < 24
-Provides:       python3-rust2rpm-core = %{version}-%{release}
 Obsoletes:      python3-rust2rpm-core < 24
+
+# The python3.11 version should not Provide python3-XXX (it's not sufficiently
+# compatible), but it should Obsolete the old version.
+%if "%{python3_pkgversion}" == "3"
+Provides:       python3-rust2rpm-core = %{version}-%{release}
+Provides:       python3-rust2rpm = %{version}-%{release}
+%endif
 
 %description
 rust2rpm is a tool that automates the generation of RPM spec files for
@@ -45,7 +54,7 @@ Rust crates.
 %autosetup -n rust2rpm-%{shortcommit} -p1
 
 %generate_buildrequires
-%pyproject_buildrequires -t
+%pyproject_buildrequires
 
 %build
 %pyproject_wheel
@@ -58,7 +67,7 @@ rm %{buildroot}/%{_bindir}/cargo-inspector
 
 %check
 %if %{with check}
-%tox
+%pytest
 %endif
 
 %files

--- a/rust2rpm/rust2rpm.spec
+++ b/rust2rpm/rust2rpm.spec
@@ -29,7 +29,6 @@ Requires:       cargo2rpm
 Requires:       cargo-rpm-macros
 
 # obsolete old Provides
-Obsoletes:      rust2rpm < 24
 Obsoletes:      cargo-inspector < 24
 
 # obsolete + provide removed Python subpackages


### PR DESCRIPTION
I figured I'd take a stab at this; I've been testing the python3.11 stack in EPEL 9. You can test this in an epel9-next mock chroot (you'll need `--enablerepo=local-centos-stream` or `https://kojihub.stream.centos.org/kojifiles/repos/c9s-build/latest/$basearch/` in copr for now) or wait until ~May for 9.2.

See the detailed commit messages. I didn't touch the changelog entries or SRPMs. Feel free to push to my fork and format them how you want.